### PR TITLE
fix: use named volumes for postgres and rabbitmq, add .env.template, …

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,4 @@
+# postgres
+POSTGRES_USER=user
+POSTGRES_PASSWORD=password
+POSTGRES_DB=database

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - rabbitmq
 
   web-proxy:
-    image: nginx:latest
+    image: nginx:1.29.0
     container_name: ml_nginx
     depends_on:
       - app
@@ -23,13 +23,13 @@ services:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
 
   rabbitmq:
-    image: rabbitmq:latest
+    image: rabbitmq:4.1.2
     container_name: ml_rabbitmq
     ports:
       - "15672:15672"
       - "5672:5672"
     volumes:
-      - ./rabbitmq/data:/var/lib/rabbitmq
+      - rabbitdata:/var/lib/rabbitmq
     restart: on-failure
 
   database:
@@ -38,4 +38,8 @@ services:
     env_file:
       - .env
     volumes:
-      - ./postgres/data:/var/lib/postgresql/data
+      - pgdata:/var/lib/postgresql/data
+
+volumes:
+  pgdata:
+  rabbitdata:

--- a/src/app/Dockerfile
+++ b/src/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.13.5-slim
 
 WORKDIR /app
 


### PR DESCRIPTION
…specify specific versions for images